### PR TITLE
set max vllm version to 0.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "accelerate",
     "bitsandbytes",
     "numba",
-    "vllm>=0.6.6,<0.8.4; sys_platform == 'linux'",
+    "vllm>=0.6.6,<0.8.5; sys_platform == 'linux'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "accelerate",
     "bitsandbytes",
     "numba",
-    "vllm>=0.6.6,<1.0.0; sys_platform == 'linux'",
+    "vllm>=0.6.6,<0.8.4; sys_platform == 'linux'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`vllm` version 0.8.5 seems to have introduced a breaking change for our integration. This PR sets the max version in the `pyproject.toml` to 0.8.4.