### PR TITLE
Fix CI: pin peft<0.19 and drop invalid mkdocstrings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 <div align="center">
 
-[![Docs](https://github.com/genlm/genlm-backend/actions/workflows/docs.yml/badge.svg)](https://genlm.github.io/backend/)
-[![Tests](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml/badge.svg)](https://github.com/genlm/backend/actions/workflows/pytest.yml)
+[![Docs](https://github.com/genlm/genlm-backend/actions/workflows/docs.yml/badge.svg)](https://genlm.github.io/genlm-backend/)
+[![Tests](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml/badge.svg)](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml)
 [![codecov](https://codecov.io/github/genlm/genlm-backend/graph/badge.svg?token=PwmHwMJC2y)](https://codecov.io/github/genlm/genlm-backend)
 [![PyPI](https://img.shields.io/pypi/v/genlm-backend?label=pypi)](https://pypi.org/project/genlm-backend/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 ![Logo](images/logo.png)
 
 
-[![Docs](https://github.com/genlm/genlm-backend/actions/workflows/docs.yml/badge.svg)](https://genlm.github.io/backend/)
-[![Tests](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml/badge.svg)](https://github.com/genlm/backend/actions/workflows/pytest.yml)
+[![Docs](https://github.com/genlm/genlm-backend/actions/workflows/docs.yml/badge.svg)](https://genlm.github.io/genlm-backend/)
+[![Tests](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml/badge.svg)](https://github.com/genlm/genlm-backend/actions/workflows/pytest.yml)
 [![codecov](https://codecov.io/github/genlm/genlm-backend/graph/badge.svg?token=PwmHwMJC2y)](https://codecov.io/github/genlm/genlm-backend)
 [![PyPI](https://img.shields.io/pypi/v/genlm-backend?label=pypi)](https://pypi.org/project/genlm-backend/)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,6 @@ plugins:
         python:
           options:
             members_order: source
-            members_order_submodules: source
             group_by_category: false
   - gen-files:
       scripts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ sgl = [
     "sglang>=0.5.8,<0.5.9",
 ]
 lora = [
-    'peft'
+    "peft>=0.18,<0.19",
 ]
 docs = [
     "mkdocs",


### PR DESCRIPTION
## Summary

Three surgical fixes: two for CI failures introduced by upstream dep drift on the post-#60 push to main, plus a stale README badge typo surfaced while debugging.

- **`pyproject.toml`**: Pin `peft>=0.18,<0.19` in the `[lora]` extra. `peft 0.19.0` (released 2026-04-14) imports `EmbeddingParallel` from `transformers.integrations.tensor_parallel`, which is not present in our installed `transformers 4.57.6`. This broke 3 setup errors in `test_lora.py` under the `test_vllm_coverage` job.
- **`mkdocs.yml`**: Remove `members_order_submodules: source`. This is not a valid `PythonOptions` kwarg in `mkdocstrings-python 2.0.3`. It was previously masked by a richer install environment (vllm's transitive deps registered an option-accepting handler); after #60 moved vllm to an optional `[vllm]` extra, the docs deploy installs a slim env where the mask is gone and the build aborts.
- **`README.md` and `docs/index.md`**: Fix Docs and Tests badge links missing the `genlm-` repo prefix (pointed to `genlm.github.io/backend/` and `github.com/genlm/backend/...` instead of the `genlm-backend` paths). Image URLs were already correct; only the click-through targets were wrong.

## Test plan

- [x] `Docs` workflow run on this branch succeeds
- [x] `GPU tests + code coverage` workflow's `test_vllm_coverage` job passes the LoRA setup
- [x] No new regressions in `test_sgl_coverage` / `test_mlx_coverage`
- [x] Clicking the Docs and Tests badges in the rendered README resolves to the correct URL