### PR TITLE
Compute logprobs in fp32 for HF and MLX backends

### DIFF
--- a/genlm/backend/cache.py
+++ b/genlm/backend/cache.py
@@ -93,7 +93,7 @@ class TokenTrie:
         for j in range(next_token_index, len(token_ids)):
             token_id = token_ids[j]
             token_logits = logits[j - base]
-            token_logprobs = torch.log_softmax(token_logits, 0)
+            token_logprobs = torch.log_softmax(token_logits, 0, dtype=torch.float32)
 
             node = node.add_token(token_id, token_logprobs.cpu())
 

--- a/genlm/backend/llm/hf.py
+++ b/genlm/backend/llm/hf.py
@@ -419,4 +419,4 @@ class AsyncTransformer(AsyncLM):
                 past_key_values=None,
                 use_cache=False,
             ).logits[0]
-            return torch.log_softmax(logits[-1], dim=0)
+            return torch.log_softmax(logits[-1], dim=0, dtype=torch.float32)

--- a/genlm/backend/llm/mlx.py
+++ b/genlm/backend/llm/mlx.py
@@ -342,7 +342,7 @@ else:
                 inputs_padded = inputs_padded[:, n_to_process:]
 
             logits = self.mlx_lm_model(inputs_padded, cache=prompt_cache)
-            logits = logits[:, -1, :]
+            logits = logits[:, -1, :].astype(mx.float32)
             logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
             mx.async_eval(logprobs)
 


### PR DESCRIPTION
## Summary

`torch.log_softmax(bf16_in)` returns a bf16 tensor; the per-element bf16 storage precision loses information in the tail of the distribution. This change forces fp32 output at the three sites where logprobs are emitted from bf16 logits:

- \`cache.py:96\` — HF cached path
- \`hf.py:422\` — HF uncached path
- \`mlx.py:345\` — MLX manual \`z - logsumexp(z)\`; casting \`logits\` to fp32 also bypasses the bf16→fp16 downcast at \`_to_torch:148\`

vLLM and SGL already do the softmax in fp32 internally (their sampler stage upcasts before any logits-processor hook), so no change is needed there.

## Measured impact

Qwen2.5-1.5B-Instruct (bf16), 22 (prompt, position) pairs. Worst-case absolute logprob error per gold-prob magnitude bin, between the patched and unpatched versions of each backend:

| bin (logprob range, nats) | HF L∞ | MLX L∞ |
|---|---|---|
| head  [−2.3, 0]      | 0.008 | 0.062 |
| upper [−6.9, −2.3)   | 0.020 | 0.062 |
| mid   [−13.8, −6.9)  | 0.037 | 0.062 |
| tail  [−27.6, −13.8) | 0.069 | 0.124 |
| deep  [−69.1, −27.6) | 0.126 | 0.187 |

The deep-bin Δlogp of 0.126 corresponds to ~13% multiplicative error in tail probability. The MLX floor of ~0.062 across head/upper/mid is the bf16→fp16 downcast in \`_to_torch\`, which the upstream fp32 cast bypasses.

Argmax does not change at any position on either backend; this only affects code that consumes logprob *values* (constrained-gen masking, SMC particle weights, KL terms).

## Test plan
- [ ] \`pytest tests/test_hf_llm.py --benchmark-disable\` passes
- [ ] \`pytest tests/test_mlx.py --benchmark-disable\` passes (on a macOS+MLX machine)
- [ ] \`pytest tests/test_llm.py --benchmark-disable\` passes (cross-backend agreement assertions still within current tolerances)