### PR TITLE
ci: GPU tests opt-out + non-blocking (skip-gpu-tests label, gpu-gate, queue watchdog)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,14 +3,21 @@ name: GPU tests + code coverage
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
 
+concurrency:
+  group: gpu-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test_vllm_coverage:
-    runs-on: ParallelHoss
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-gpu-tests') }}
+    runs-on:
+      group: gpu-runners
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +52,10 @@ jobs:
           slug: genlm/genlm-backend
 
   test_sgl_coverage:
-    runs-on: ParallelHoss
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-gpu-tests') }}
+    runs-on:
+      group: gpu-runners
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -109,3 +119,27 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.json
           slug: genlm/genlm-backend
+
+  gpu-gate:
+    # The single required status check for GPU tests.
+    # Passes when the GPU jobs succeed OR are intentionally skipped
+    # (skip-gpu-tests label, or non-PR paths); fails on failure/cancelled
+    # (including the watchdog cancel or GitHub's 24h queue cancel).
+    # Intentionally gates only the GPU jobs; test_mlx_coverage has its own check.
+    if: ${{ always() }}
+    needs: [test_vllm_coverage, test_sgl_coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require GPU jobs to pass or be intentionally skipped
+        env:
+          VLLM_RESULT: ${{ needs.test_vllm_coverage.result }}
+          SGL_RESULT: ${{ needs.test_sgl_coverage.result }}
+        run: |
+          set -euo pipefail
+          echo "test_vllm_coverage=$VLLM_RESULT  test_sgl_coverage=$SGL_RESULT"
+          for r in "$VLLM_RESULT" "$SGL_RESULT"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::GPU job result '$r'. Re-run, or apply the 'skip-gpu-tests' label to merge without GPU CI."; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/gpu-queue-watchdog.yml
+++ b/.github/workflows/gpu-queue-watchdog.yml
@@ -1,0 +1,42 @@
+name: GPU queue watchdog
+
+# Cancels GPU runs stuck in the "queued" state past a threshold, so a PR
+# whose GPU jobs can't be scheduled fails fast (and its gpu-gate goes red)
+# instead of sitting queued for GitHub's 24h maximum.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-stale-queued:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      WORKFLOW: coverage.yml
+      MAX_QUEUED_MIN: 20
+    steps:
+      - name: Cancel GPU runs stuck queued past threshold
+        run: |
+          set -euo pipefail
+          now=$(date -u +%s)
+          # Capture first so a gh/API failure fails the step (red) instead of silently no-op'ing.
+          queued=$(gh run list -R "$GITHUB_REPOSITORY" --workflow="$WORKFLOW" \
+            --status queued --json databaseId,createdAt -L 50)
+          echo "$queued" | jq -c '.[]' | while IFS= read -r row; do
+            id=$(echo "$row" | jq -r '.databaseId')
+            created=$(echo "$row" | jq -r '.createdAt')
+            # GNU date only (ubuntu-latest); use 'date -j -f' on macOS runners.
+            created_s=$(date -u -d "$created" +%s)
+            age_min=$(( (now - created_s) / 60 ))
+            if [ "$age_min" -ge "$MAX_QUEUED_MIN" ]; then
+              echo "Cancelling run $id (queued ${age_min}m >= ${MAX_QUEUED_MIN}m)"
+              gh run cancel "$id" -R "$GITHUB_REPOSITORY" || true
+            else
+              echo "Run $id queued ${age_min}m (< ${MAX_QUEUED_MIN}m) — leaving"
+            fi
+          done


### PR DESCRIPTION
## Summary
- GPU tests (`test_vllm_coverage`, `test_sgl_coverage`) now run **by default** but can be skipped by a maintainer applying a **`skip-gpu-tests`** label. External/fork PRs can't apply labels, so GPU stays required for them.
- New **`gpu-gate`** job aggregates the GPU job results (passes on `success`/`skipped`, fails on `failure`/`cancelled`). It is intended to become the **single required status check** for GPU, replacing the raw job names — so a skipped or dead GPU run no longer leaves a `cancelled` check blocking merges.
- GPU jobs now target the **`gpu-runners`** group (failover across `ParallelHoss` + `ParallelHoss2`, and the two jobs run in parallel); added `timeout-minutes: 60` and `concurrency: cancel-in-progress`.
- New scheduled **`gpu-queue-watchdog`** cancels runs stuck in `queued` > 20 min so PRs fail fast instead of hitting GitHub's 24h queue timeout.

**Background:** GPU runs had been auto-cancelled at the 24h queue cap for ~3 weeks (runner not accepting jobs), blocking PRs.

## Required follow-up after merge (maintainer / org admin)
- [ ] Branch protection → required status checks: add **`gpu-gate`**, remove `test_vllm_coverage` / `test_sgl_coverage`.
- [ ] Create the **`skip-gpu-tests`** label.
- [ ] Settings → Actions → General → **"Require approval for all external contributors"**.
- [ ] Confirm a real GPU run now completes on the `gpu-runners` group; cancel the lingering ~May-7 zombie run.

## Test plan
- [ ] On this PR, GPU jobs start on a `gpu-runners` runner (not stuck `queued`).
- [ ] Apply `skip-gpu-tests` → GPU jobs show `skipped`, `gpu-gate` is green, PR mergeable.
- [ ] Manually dispatch `gpu-queue-watchdog` once → runs clean.